### PR TITLE
define expectedsize for decompressor

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -79,3 +79,17 @@ function TranscodingStreams.process(codec::ZstdDecompressor, input::Memory, outp
         return Δin, Δout, code == 0 ? :end : :ok
     end
 end
+
+function TranscodingStreams.expectedsize(codec::ZstdDecompressor, input::Memory)
+    ret = find_decompressed_size(input.ptr, input.size)
+    if ret == ZSTD_CONTENTSIZE_ERROR
+        # something is bad, but we ignore it here
+        return Int(input.size)
+    elseif ret == ZSTD_CONTENTSIZE_UNKNOWN
+        # random guess
+        return Int(input.size * 2)
+    else
+        # exact size
+        return Int(ret)
+    end
+end

--- a/src/libzstd.jl
+++ b/src/libzstd.jl
@@ -103,3 +103,14 @@ end
 function free!(dstream::DStream)
     return ccall((:ZSTD_freeDStream, libzstd), Csize_t, (Ptr{Cvoid},), dstream.ptr)
 end
+
+
+# Misc. functions
+# ---------------
+
+const ZSTD_CONTENTSIZE_UNKNOWN = Culonglong(0) - 1
+const ZSTD_CONTENTSIZE_ERROR   = Culonglong(0) - 2
+
+function find_decompressed_size(src::Ptr, size::Integer)
+    return ccall((:ZSTD_findDecompressedSize, libzstd), Culonglong, (Ptr{Cvoid}, Csize_t), src, size)
+end


### PR DESCRIPTION
This will completely solve #13 along with https://github.com/bicycle1885/TranscodingStreams.jl/pull/87.

```
~/w/TranscodingStreams (master|…) $ julia buffering.zstd.jl
  7.502553 seconds (43.78 k allocations: 3.051 GiB, 0.65% gc time)
  7.803480 seconds (11 allocations: 3.049 GiB, 3.52% gc time)
  7.846319 seconds (11 allocations: 3.049 GiB, 3.32% gc time)
  7.654522 seconds (11 allocations: 3.049 GiB, 2.49% gc time)
  7.714356 seconds (11 allocations: 3.049 GiB, 2.87% gc time)
```

```
~/w/TranscodingStreams (master|…) $ ipython
Python 3.7.2 (v3.7.2:9a3ffc0492, Dec 24 2018, 02:44:43)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.6.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import zstandard

In [2]: data = open('hg38.fa.zst', 'rb').read();

In [3]: %timeit zstandard.ZstdDecompressor().decompress(data);
7.73 s ± 40.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```